### PR TITLE
fix(useAuth): fix ReferenceError in handleAuthResult

### DIFF
--- a/src/useAuth.js
+++ b/src/useAuth.js
@@ -24,7 +24,7 @@ async function setSession({ dispatch, auth0, authResult }) {
     });
 }
 
-export const handleAuthResult = async ({ dispatch, auth0, authResult }) => {
+export const handleAuthResult = async ({ err, dispatch, auth0, authResult }) => {
     if (authResult && authResult.accessToken && authResult.idToken) {
         await setSession({ dispatch, auth0, authResult });
 


### PR DESCRIPTION
Hi!

`err` is undefined in `handleAuthResult` as it is missing in the argument destructuring. This PR fixes that.

Cheers!