### PR TITLE
add isAuthenticating state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h1 align="center">useAuth – the simplest way to add authentication to your React app</h1>
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors)
+
 <p>
   <img alt="Version" src="https://img.shields.io/badge/version-0.1.0-blue.svg?cacheSeconds=2592000" />
   <a href="https://github.com/Swizec/useAuth/blob/master/LICENSE">

--- a/src/AuthProvider.js
+++ b/src/AuthProvider.js
@@ -34,7 +34,8 @@ export const AuthProvider = ({
     // Holds authentication state
     const [state, dispatch] = useReducer(authReducer, {
         user: {},
-        expiresAt: null
+        expiresAt: null,
+        isAuthenticating: false
     });
 
     const [contextValue, setContextValue] = useState({
@@ -55,7 +56,13 @@ export const AuthProvider = ({
     // Verify user is logged-in on AuthProvider mount
     // Avoids storing sensitive data in local storage
     useEffect(() => {
+        dispatch({
+            type: "authenticating"
+        });
         auth0.checkSession({}, (err, authResult) => {
+            dispatch({
+                type: "authenticating"
+            });
             if (err) {
                 dispatch({
                     type: "error",

--- a/src/authReducer.js
+++ b/src/authReducer.js
@@ -28,6 +28,11 @@ export const authReducer = (state, action) => {
                 expiresAt: null,
                 authResult: null
             };
+        case "authenticating":
+            return {
+                ...state,
+                isAuthenticating: !state.isAuthenticating
+            };
         case "error":
             const { errorType, error } = action;
             return {

--- a/src/useAuth.js
+++ b/src/useAuth.js
@@ -69,8 +69,15 @@ export const useAuth = () => {
 
     const handleAuthentication = ({ postLoginRoute = "/" } = {}) => {
         if (typeof window !== "undefined") {
+            dispatch({
+                type: "authenticating"
+            });
+
             auth0.parseHash(async (err, authResult) => {
                 await handleAuthResult({ err, authResult, dispatch, auth0 });
+                dispatch({
+                    type: "authenticating"
+                });
 
                 navigate(postLoginRoute);
             });
@@ -82,6 +89,7 @@ export const useAuth = () => {
     };
 
     return {
+        isAuthenticating: state.isAuthenticating,
         isAuthenticated,
         user: state.user,
         userId: state.user ? state.user.sub : null,


### PR DESCRIPTION
I'm writing an app that uses Apollo and need to conditionally send users to different pages from the login callback based upon database responses. I found that when the app mounts it can take a little bit of time for all the authentication details to be processed, this `isAuthenticating` state allows me to use a lazy query and conditionally execute it when the time is ready.

I've tried to find all of the different areas where this `dispatch` needs to be fired but @Swizec  please check if I've missed anything else! 

### Sidenote: 

I feel the docs could be upgraded a bit as well, the guide is great but some details on the API of the `useAuth` would be worthwhile. Let me know your thoughts and I can have stab sometime this week,