### PR TITLE
Remove console.log, change dispatch order and new isAuthenticating initial value

### DIFF
--- a/src/AuthProvider.js
+++ b/src/AuthProvider.js
@@ -35,7 +35,7 @@ export const AuthProvider = ({
     const [state, dispatch] = useReducer(authReducer, {
         user: {},
         expiresAt: null,
-        isAuthenticating: false
+        isAuthenticating: true
     });
 
     const [contextValue, setContextValue] = useState({

--- a/src/useAuth.js
+++ b/src/useAuth.js
@@ -30,11 +30,13 @@ export const handleAuthResult = async ({
     auth0,
     authResult
 }) => {
+    
+    dispatch({
+        type: "stopAuthenticating"
 
     if (authResult && authResult.accessToken && authResult.idToken) {
         await setSession({ dispatch, auth0, authResult });
-        dispatch({
-        type: "stopAuthenticating"
+        
     });
 
         return true;

--- a/src/useAuth.js
+++ b/src/useAuth.js
@@ -30,14 +30,12 @@ export const handleAuthResult = async ({
     auth0,
     authResult
 }) => {
-    console.log("HAI");
-
-    dispatch({
-        type: "stopAuthenticating"
-    });
 
     if (authResult && authResult.accessToken && authResult.idToken) {
         await setSession({ dispatch, auth0, authResult });
+        dispatch({
+        type: "stopAuthenticating"
+    });
 
         return true;
     } else if (err) {


### PR DESCRIPTION
I suggest these changes:
1. Removed one console.log statement.
2. Change the order of the dispatch to be after the session is set.
3. Set `isAuthenticating` to true for its initial value. In the very first render of useAuth both `isAuthenticating` and `isAuthenticated()` are false, making it hard to test for case where the authentication has just started.
