### PR TITLE
Fix type issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "main": "dist/index.js",
     "module": "dist/index.module.js",
     "unpkg": "dist/index.umd.js",
-    "types": "dist/types.d.ts",
     "repository": "git@github.com:Swizec/useAuth.git",
     "author": "Swizec Teller <swizec@swizec.com>",
     "license": "MIT",

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type AuthProviderInterface = ({
     auth0_domain: string;
     auth0_client_id: string;
     auth0_params: AuthOptions;
-}) => ReactNode;
+}) => JSX.Element;
 
 export type AuthContextState = {
     state: AuthState;


### PR DESCRIPTION
1. Removed types from package.json (it pointed to the wrong declaration file). Typescript should find index.d.ts automatically. 
2. AuthProvider need to return a JSX.Element (see https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/issues/129). It may be better to just type the props and let the rest be inferred. 