### PR TITLE
Support custom domains

### DIFF
--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -50,6 +50,7 @@ export const AuthContext = createContext<AuthContextState>({
 export const AuthProvider: AuthProviderInterface = ({
     children,
     navigate,
+    auth0_audience_domain,
     auth0_domain,
     auth0_client_id,
     auth0_params
@@ -63,7 +64,7 @@ export const AuthProvider: AuthProviderInterface = ({
         domain: auth0_domain,
         clientID: auth0_client_id,
         redirectUri: `${callback_domain}/auth0_callback`,
-        audience: `https://${auth0_domain}/api/v2/`,
+        audience: `https://${auth0_audience_domain}/api/v2/`,
         responseType: "token id_token",
         scope: "openid profile email"
     };


### PR DESCRIPTION
While using custom domain the `*/api/v2` URL must preserve the *.auth0.com domain name.

https://auth0.com/docs/custom-domains/troubleshoot#-service-not-found-