### PR TITLE
Fix version number for @types/react in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "devDependencies": {
         "@types/auth0-js": "^9.10.6",
         "@types/jest": "^25.1.4",
-        "@types/react": "^16.13.1",
+        "@types/react": "^16.9.34",
         "eslint": "^6.1.0",
         "eslint-config-prettier": "^6.0.0",
         "eslint-plugin-prettier": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,7 +1251,7 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/react@^16.13.1":
+"@types/react@^16.9.34":
   version "16.9.34"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
   integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==


### PR DESCRIPTION
Looks like this was accidentally changed to match the React version in bb1fd1f. Switched back to the latest released version.