### PR TITLE
Switch to commonjs

### DIFF
--- a/auth0.js
+++ b/auth0.js
@@ -1,4 +1,5 @@
 // this is a hack to improve DX
 // TODO: figure out a better way
 
-export { Auth0 } from "./dist/auth0";
+const { Auth0 } = require("./dist/auth0")
+module.exports = { Auth0 }

--- a/examples/useauth-create-next-app/package.json
+++ b/examples/useauth-create-next-app/package.json
@@ -12,7 +12,7 @@
         "next": "9.3.2",
         "react": "16.10.2",
         "react-dom": "16.10.2",
-        "react-use-auth": "^0.5.1",
+        "react-use-auth": "2.0.2",
         "rebass": "^4.0.6"
     }
 }

--- a/examples/useauth-create-next-app/pages/_app.js
+++ b/examples/useauth-create-next-app/pages/_app.js
@@ -1,25 +1,23 @@
-import React from "react";
-import App from "next/app";
-import { AuthProvider } from "react-use-auth";
+
+import { AuthConfig } from "react-use-auth";
+import { Auth0 } from "react-use-auth/auth0";
 import { useRouter } from "next/router";
 
 function MyApp({ Component, pageProps }) {
     const router = useRouter();
-
     return (
-        <AuthProvider
-            navigate={router.push}
-            auth0_domain="useauth.auth0.com"
-            auth0_client_id="GjWNFNOHq1ino7lQNJBwEywa1aYtbIzh"
-        >
+        <>
+            <AuthConfig
+                authProvider={Auth0}
+                navigate={(url) => router.push(url)}
+                params={{
+                    domain: "webreplay.us.auth0.com",
+                    clientID: "E1B33wDDkz0J4mUC2WAVA2552Fj91uux"
+                }}
+            />
             <Component {...pageProps} />
-        </AuthProvider>
+        </>
     );
 }
 
-// extend App component and return our function so we can use useRouter :P
-export default class _App extends App {
-    render() {
-        return <MyApp {...this.props} />;
-    }
-}
+export default MyApp


### PR DESCRIPTION
I see this exception when I build with `nextjs` with the example. This problem goes away once I switch to commonjs. This makes sense if nextjs avoids running babel on 3rd party dependencies.

```
export { Auth0 } from "./dist/auth0";
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:1047:16)
    at Module._compile (internal/modules/cjs/loader.js:1097:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Module.require (internal/modules/cjs/loader.js:1019:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at eval (webpack-internal:///react-use-auth/auth0:1:18)
    at Object.react-use-auth/auth0 (/Users/jasonlaster/src/_daily/Dec-16/next-auth/.next/server/pages/_app.js:160:1)
    at __webpack_require__ (/Users/jasonlaster/src/_daily/Dec-16/next-auth/.next/server/pages/_app.js:23:31)
/Users/jasonlaster/src/_daily/Dec-16/next-auth/node_modules/react-use-auth/auth0.js:4
export { Auth0 } from "./dist/auth0";
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:1047:16)
    at Module._compile (internal/modules/cjs/loader.js:1097:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Module.require (internal/modules/cjs/loader.js:1019:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at eval (webpack-internal:///react-use-auth/auth0:1:18)
    at Object.react-use-auth/auth0 (/Users/jasonlaster/src/_daily/Dec-16/next-auth/.next/server/pages/_app.js:160:1)
    at __webpack_require__ (/Users/jasonlaster/src/_daily/Dec-16/next-auth/.next/server/pages/_app.js:23:31)
```